### PR TITLE
TypeError: can't convert CUDA tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first

### DIFF
--- a/train.py
+++ b/train.py
@@ -142,8 +142,8 @@ def main():
     print('End to initalize...')
 
     while True:
-        total_state, total_reward, total_done, total_next_state, total_action, total_int_reward, total_next_obs, total_ext_values, total_int_values, total_policy = \
-            [], [], [], [], [], [], [], [], [], []
+        total_state, total_reward, total_done, total_next_state, total_action, total_int_reward, total_next_obs, total_ext_values, total_int_values, total_policy, total_policy_np = \
+            [], [], [], [], [], [], [], [], [], [], []
         global_step += (num_worker * num_step)
         global_update += 1
 
@@ -185,6 +185,7 @@ def main():
             total_ext_values.append(value_ext)
             total_int_values.append(value_int)
             total_policy.append(policy)
+            total_policy_np.append(policy.cpu().numpy())
 
             states = next_states[:, :, :, :]
 
@@ -213,7 +214,7 @@ def main():
         total_next_obs = np.stack(total_next_obs).transpose([1, 0, 2, 3, 4]).reshape([-1, 1, 84, 84])
         total_ext_values = np.stack(total_ext_values).transpose()
         total_int_values = np.stack(total_int_values).transpose()
-        total_logging_policy = np.vstack(total_policy)
+        total_logging_policy = np.vstack(total_policy_np)
 
         # Step 2. calculate intrinsic reward
         # running mean intrinsic reward


### PR DESCRIPTION
Problem: TypeError: can't convert CUDA tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first. GPU only problem.

```
Traceback (most recent call last):
  File "train.py", line 274, in <module>
    main()
  File "train.py", line 216, in main
    total_logging_policy = np.vstack(total_policy)
  File "/home/deployer/.pyenv/versions/3.6.8/envs/general/lib/python3.6/site-packages/numpy/core/shape_base.py", line 234, in vstack
    return _nx.concatenate([atleast_2d(_m) for _m in tup], 0)
  File "/home/deployer/.pyenv/versions/3.6.8/envs/general/lib/python3.6/site-packages/numpy/core/shape_base.py", line 234, in <listcomp>
    return _nx.concatenate([atleast_2d(_m) for _m in tup], 0)
  File "/home/deployer/.pyenv/versions/3.6.8/envs/general/lib/python3.6/site-packages/numpy/core/shape_base.py", line 102, in atleast_2d
    ary = asanyarray(ary)
  File "/home/deployer/.pyenv/versions/3.6.8/envs/general/lib/python3.6/site-packages/numpy/core/numeric.py", line 553, in asanyarray
    return array(a, dtype, copy=False, order=order, subok=True)
  File "/home/deployer/.pyenv/versions/3.6.8/envs/general/lib/python3.6/site-packages/torch/tensor.py", line 450, in __array__
    return self.numpy()
TypeError: can't convert CUDA tensor to numpy. Use Tensor.cpu() to copy the tensor to host memory first.
```